### PR TITLE
Add keywords home page, As a user, I can view the list of keywords and filter them

### DIFF
--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -1,5 +1,6 @@
 class KeywordsController < ApplicationController
-    before_action :require_login, only: [:index, :secret]
+    # Before the action, check if user is logged in.
+    before_action :require_login, only: [:index]
 
     # index is a public page
     def index
@@ -8,12 +9,5 @@ class KeywordsController < ApplicationController
         else
             @keywords = Keyword.where(user_id: session[:user_id])
         end   
-    end
-  
-    # secret is a private page, only logged-in user can enter
-    def secret
-      if current_user.blank?
-        render plain: '401 Unauthorized', status: :unauthorized
-      end
     end
   end

--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -3,7 +3,11 @@ class KeywordsController < ApplicationController
 
     # index is a public page
     def index
- 
+        if params[:query].present?
+            @keywords = Keyword.where("user_id = ? AND keyword ILIKE ?", session[:user_id], "%#{params[:query]}%")
+        else
+            @keywords = Keyword.where(user_id: session[:user_id])
+        end   
     end
   
     # secret is a private page, only logged-in user can enter

--- a/app/models/keyword.rb
+++ b/app/models/keyword.rb
@@ -1,0 +1,3 @@
+class Keyword < ApplicationRecord
+  belongs_to :user
+end

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,33 +1,27 @@
-<div class="grid grid-cols-4 gap-4">
+<div class="grid grid-cols-1 w-full p-6">
     <% if current_user %>
-        <div class="col-start-2 col-span-2">
-            <h1>Welcome, <%= current_user.username %></h1>
-            <%= link_to 'Logout', user_session_path(current_user), data: { turbo_method: :delete }, class: "btn-primary" %><br><br>
-        </div>
-        <%= form_with(url: keywords_path, method: :get, data: {turbo_frame: "keywords"}, class: "col-start-2 col-span-2") do |form| %>
-            <%= form.label :query, "Search by keyword:", class: "block mb-2" %>
+        <%= form_with(url: keywords_path, method: :get, data: {turbo_frame: "keywords"}) do |form| %>
             <div class="flex space-x-3">
-                <%= form.text_field :query, class: "py-2 px-2 rounded border ring-0 focus:ring-4 focus:ring-orange-100 focus:shadow-none focus:border-orange-500 focus:outline-none" %>
+                <%= form.text_field :query, placeholder: "Keyword...", class: "py-2 px-2 rounded border ring-0 focus:ring-4 focus:ring-orange-100 focus:shadow-none focus:border-orange-500 focus:outline-none" %>
 
                 <%= form.submit 'Search', class: "px-2 py-2 font-medium
             bg-orange-300 text-neutal-900 rounded flex items-center cursor-pointer hover:bg-orange-400 focus:ring-4 ring-0 focus:ring-orange-100" %>
             </div>
         <% end %>
-        <div class="col-start-2 col-span-2 overflow-y-auto max-h-40">
-            <table class="text-left w-full min-w-full">
-                <thead class="bg-gray-400 text-white sticky top-0">
+        <div>
+            <table class="text-left w-full min-w-full overflow-y-auto">
+                <thead class="bg-gray-400 sticky">
                     <tr>
                         <th>Keyword</th>
-                        <%# <th>Artist</th>
-                        <th>Year</th> %>
+                        <th>Action</th>
+                        <%# <th>Year</th> %>
                     </tr>
                 </thead>
                 <tbody class="overflow-y-scroll">
                     <% @keywords.each do |keyword| %>
                          <tr>
                             <td><%= keyword.keyword %></td>
-                            <%# <td>-</td>
-                            <td>-</td> %>
+                            <td>-</td>
                         </tr>
                     <% end %>
                 </tbody>
@@ -39,6 +33,4 @@
         </div>
         <%= link_to 'Login', login_path , class: "btn-primary col-span-2 col-start-2" %>
     <% end %>
-
-    <%= link_to 'Secret page', '/keywords/secret', class: "btn-primary bg-black hover:bg-gray-500 col-span-2 col-start-2" %>
 </div>

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,8 +1,44 @@
-<% if current_user %>
-  <h1>Welcome, <%= current_user.username %></h1>
-  <%= link_to 'Logout', user_session_path(current_user), data: { turbo_method: :delete }, class: "btn-primary" %><br><br>
-<% else %>
-  <h1>This is the index page</h1>
-  <%= link_to 'Login', login_path , class: "btn-primary" %><br><br>
-<% end %>
-<%= link_to 'Secret page', '/keywords/secret', class: "btn-primary" %>
+<div class="grid grid-cols-4 gap-4">
+    <% if current_user %>
+        <div class="col-start-2 col-span-2">
+            <h1>Welcome, <%= current_user.username %></h1>
+            <%= link_to 'Logout', user_session_path(current_user), data: { turbo_method: :delete }, class: "btn-primary" %><br><br>
+        </div>
+        <%= form_with(url: keywords_path, method: :get, data: {turbo_frame: "keywords"}, class: "col-start-2 col-span-2") do |form| %>
+            <%= form.label :query, "Search by keyword:", class: "block mb-2" %>
+            <div class="flex space-x-3">
+                <%= form.text_field :query, class: "py-2 px-2 rounded border ring-0 focus:ring-4 focus:ring-orange-100 focus:shadow-none focus:border-orange-500 focus:outline-none" %>
+
+                <%= form.submit 'Search', class: "px-2 py-2 font-medium
+            bg-orange-300 text-neutal-900 rounded flex items-center cursor-pointer hover:bg-orange-400 focus:ring-4 ring-0 focus:ring-orange-100" %>
+            </div>
+        <% end %>
+        <div class="col-start-2 col-span-2 overflow-y-auto max-h-40">
+            <table class="text-left w-full min-w-full">
+                <thead class="bg-gray-400 text-white sticky top-0">
+                    <tr>
+                        <th>Keyword</th>
+                        <%# <th>Artist</th>
+                        <th>Year</th> %>
+                    </tr>
+                </thead>
+                <tbody class="overflow-y-scroll">
+                    <% @keywords.each do |keyword| %>
+                         <tr>
+                            <td><%= keyword.keyword %></td>
+                            <%# <td>-</td>
+                            <td>-</td> %>
+                        </tr>
+                    <% end %>
+                </tbody>
+            </table>
+        </div>
+    <% else %>
+        <div class="col-start-2 col-span-2">
+            <h1>This is the index page</h1>
+        </div>
+        <%= link_to 'Login', login_path , class: "btn-primary col-span-2 col-start-2" %>
+    <% end %>
+
+    <%= link_to 'Secret page', '/keywords/secret', class: "btn-primary bg-black hover:bg-gray-500 col-span-2 col-start-2" %>
+</div>

--- a/app/views/keywords/secret.html.erb
+++ b/app/views/keywords/secret.html.erb
@@ -1,1 +1,0 @@
-<h1>This is the secret page</h1>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,12 +11,35 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body class="prose mx-auto flex flex-col justify-center items-center h-screen">
-    <% flash.each do |type, msg| %>
-      <div>
-        <%= msg %>
-      </div>
+  <body class="mx-auto">
+    <% if current_user %>
+      <nav class="bg-white shadow-md w-full">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="flex justify-between h-16">
+            <div class="flex">
+              <div class="flex-shrink-0 flex items-center">
+                <%= link_to root_path do %>
+                  <%= image_tag("scrappy-doo-cropped.png", :alt => "scrappy logo", class: "rounded-full ring ring-pink-500 w-12 h-12 bg-amber-400") %>
+                <% end %>
+              </div>
+            </div>
+            <div class="hidden md:ml-6 md:flex md:items-center">
+                <h1>Welcome, <%= current_user.username %></h1>
+                <%= link_to 'Logout', user_session_path(current_user), data: { turbo_method: :delete }, class: "text-gray-900 hover:text-gray-700 px-3 py-2 rounded-md text-sm font-medium" %><br><br>
+            </div>
+          </div>
+        </div>
+      </nav>
     <% end %>
-    <%= yield %>
+    
+    <div class="prose mx-auto">
+      <% flash.each do |type, msg| %>
+        <div>
+          <%= msg %>
+        </div>
+      <% end %>
+
+      <%= yield %>
+    </div>
   </body>
 </html>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Rails.application.routes.draw do
 
   resources :user_sessions, only: [:create, :destroy]
   resources :users, only: [:index, :create, :authenticate]
+  resources :keywords, only: [:index]
 end

--- a/db/migrate/20240525063544_create_keywords.rb
+++ b/db/migrate/20240525063544_create_keywords.rb
@@ -1,0 +1,10 @@
+class CreateKeywords < ActiveRecord::Migration[7.1]
+  def change
+    create_table :keywords do |t|
+      t.string :keyword
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_24_143624) do
+ActiveRecord::Schema[7.1].define(version: 2024_05_25_063544) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "keywords", force: :cascade do |t|
+    t.string "keyword"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_keywords_on_user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "username"
@@ -23,4 +31,5 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_24_143624) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "keywords", "users"
 end

--- a/test/fixtures/keywords.yml
+++ b/test/fixtures/keywords.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  keyword: MyString
+  user: one
+
+two:
+  keyword: MyString
+  user: two

--- a/test/models/keyword_test.rb
+++ b/test/models/keyword_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class KeywordTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## What happened 👀
- [UI] Implemented keywords page
- [UI] Implemented keywords filter
- [UI] Implemented navigation bar

## Insight 📝

I added a simple table to show keywords and search bar which can filter the keyword list (case insensitive). 
I also added navigation bar to group the username and the logout button together.

## Proof Of Work 📹
<img width="883" alt="image" src="https://github.com/macropusgiganteus/scrappy-web/assets/35326900/e8d909ee-4329-4d56-a280-300ae9a561ae">

<img width="883" alt="image" src="https://github.com/macropusgiganteus/scrappy-web/assets/35326900/a83ceb1c-f356-4fce-95ed-3f8e9a40259d">

![scrappy-web-keywords-index](https://github.com/macropusgiganteus/scrappy-web/assets/35326900/f23b8d61-77a6-4600-92b0-8b45a9647636)