### PR TITLE
Add import keywords from CSV, As a user, I can import new keywords from a CSV file

### DIFF
--- a/app/controllers/keywords_controller.rb
+++ b/app/controllers/keywords_controller.rb
@@ -1,4 +1,5 @@
 class KeywordsController < ApplicationController
+    require 'csv'
     # Before the action, check if user is logged in.
     before_action :require_login, only: [:index]
 
@@ -10,4 +11,46 @@ class KeywordsController < ApplicationController
             @keywords = Keyword.where(user_id: session[:user_id])
         end   
     end
-  end
+
+    def import_csv    
+        if !params[:file].present?
+            redirect_to keywords_path, alert: "Please upload a file"
+            return true
+        end
+
+        file = params[:file]
+
+        if file.content_type != 'text/csv'
+            redirect_to keywords_path, alert: "Invalid file type. Please upload a CSV file."
+            return true
+        end
+
+        total_rows = CSV.read(file.path).count
+        if (total_rows == 0)
+            redirect_to keywords_path, alert: "The file is empty."
+            return true
+        elsif (total_rows > 100)
+            redirect_to keywords_path, alert: "Keywords exceed 100 rows."
+            return true
+        end
+
+        # Process the file
+        begin
+            CSV.foreach(file.path) do |row|
+            keyword = Keyword.new
+            keyword.keyword = row[0]
+            keyword.user = current_user
+            
+            if keyword.valid?
+                keyword.save!
+            else
+                # Handle invalid rows here, e.g., log errors
+                Rails.logger.error "Invalid row: #{keyword.errors.full_messages}"
+            end
+        end
+            redirect_to keywords_path, notice: "CSV imported successfully"
+        rescue CSV::MalformedCSVError => e
+            redirect_to keywords_path, alert: "There was an error processing the file: #{e.message}"
+        end
+    end      
+end

--- a/app/views/keywords/index.html.erb
+++ b/app/views/keywords/index.html.erb
@@ -1,13 +1,24 @@
 <div class="grid grid-cols-1 w-full p-6">
     <% if current_user %>
-        <%= form_with(url: keywords_path, method: :get, data: {turbo_frame: "keywords"}) do |form| %>
-            <div class="flex space-x-3">
-                <%= form.text_field :query, placeholder: "Keyword...", class: "py-2 px-2 rounded border ring-0 focus:ring-4 focus:ring-orange-100 focus:shadow-none focus:border-orange-500 focus:outline-none" %>
+        
+        <%= form_with url: import_keywords_path, html: {class: "grid grid-cols-4 gap-2 w-full my-2"}, local: true, multipart: true do |form| %>
+                <div class="row-span-1 col-span-4" ><%= form.label :file, "Import keywords", class: "text-base text-gray-500 font-semibold block" %></div>
+                <div class="row-span-2 col-span-3"><%= form.file_field :file, class: "w-full text-gray-400 font-semibold text-sm bg-white border file:cursor-pointer cursor-pointer file:border-0 file:py-3 file:px-4 file:mr-4 file:bg-gray-100 file:hover:bg-gray-200 file:text-gray-500 rounded", aria: { describedby: 'file_input_help' }, id: 'file_input' %></div>
+                <div class="row-span-2">
+                    <%= form.submit "Import", class: "px-4 py-2 bg-blue-500 text-white rounded-lg hover:bg-blue-600 focus:outline-none" %>
+                </div>
+                <div class="row-span-1 col-span-4"><p class="text-xs text-gray-400 mt-2" id="file_input_help">Only CSV file is allowed</p></div>
+        <% end %>
 
-                <%= form.submit 'Search', class: "px-2 py-2 font-medium
-            bg-orange-300 text-neutal-900 rounded flex items-center cursor-pointer hover:bg-orange-400 focus:ring-4 ring-0 focus:ring-orange-100" %>
+        <%= form_with(url: keywords_path, html: {class: "grid grid-cols-4 gap-2 w-full my-2"}, method: :get, data: {turbo_frame: "keywords"}) do |form| %>
+            <div class="col-span-3">
+                <%= form.text_field :query, placeholder: "Keyword...", class: "w-full py-2 px-2 rounded border ring-0 focus:ring-4 focus:ring-orange-100 focus:shadow-none focus:border-orange-500 focus:outline-none" %>
+            </div>
+            <div>
+                 <%= form.submit 'Search', class: "px-4 py-2 text-neutal-900 bg-orange-400 text-white rounded-lg hover:bg-orange-500 focus:ring-orange-100"%>
             </div>
         <% end %>
+
         <div>
             <table class="text-left w-full min-w-full overflow-y-auto">
                 <thead class="bg-gray-400 sticky">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   get 'register', to: 'users#new', as: 'register'
   get 'login', to: 'user_sessions#new', as: 'login'
 
+  post 'import_keywords', to: 'keywords#import_csv'
+
   resources :user_sessions, only: [:create, :destroy]
   resources :users, only: [:index, :create, :authenticate]
   resources :keywords, only: [:index]


### PR DESCRIPTION
## What happened 👀
- [UI] Implemented upload keywords user interface

## Insight 📝
I added a form that receive a file at keywords index page. The file get passed to `keywords#import_csv` action then get validated and finally extract and store unique keywords (keywords that doesn't exist in the DB) to the database.

## Proof Of Work 📹
<img width="839" alt="image" src="https://github.com/macropusgiganteus/scrappy-web/assets/35326900/89f36673-1a88-4e4e-a43e-32fc25424727">

![scrappy-web-import-csv](https://github.com/macropusgiganteus/scrappy-web/assets/35326900/3c1be602-21e4-46ba-8328-bd48161e3c7c)

![scrappy-web-import-duplicated-csv](https://github.com/macropusgiganteus/scrappy-web/assets/35326900/4772343c-49f9-4561-9ee6-30d5c35ddf7a)

